### PR TITLE
use arrow keys for panning

### DIFF
--- a/js/app3D.js
+++ b/js/app3D.js
@@ -68,7 +68,6 @@ define(['three', 'Clock', 'Detector', 'UI', 'Api', 'Settings', 'Storage', 'utils
             noPan: false,
             staticMoving: true,
             dynamicDampingFactor: 0.3,
-            keys: [65, 83, 68]
         },
         lights: [{
             type: 'DirectionalLight',
@@ -240,7 +239,6 @@ define(['three', 'Clock', 'Detector', 'UI', 'Api', 'Settings', 'Storage', 'utils
         app.controls.noPan = config.controls.noPan;
         app.controls.staticMoving = config.controls.staticMoving;
         app.controls.dynamicDampingFactor = config.controls.dynamicDampingFactor;
-        app.controls.keys = config.controls.keys;
     };
 
     const initRenderer = function initRenderer() {


### PR DESCRIPTION
Despite the [documentation](https://threejs.org/docs/#examples/en/controls/OrbitControls.keys) I couldn't change which keys pan the camera. So at least for now we can use the arrow keys to pan the camera.

Resolves #2.